### PR TITLE
Copy button fixed

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,6 +30,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -7,3 +7,25 @@ with some basic Sphinx docs.
 Read the tutorial here:
 
 https://docs.readthedocs.io/en/stable/tutorial/
+
+Getting Started
+---------------
+
+To start editing the group wiki, you'll need Python with `Sphinx` installed.
+This can be done through `Pip`, and involves installing the packages `sphinx`
+and `sphinx-rtd-theme`.
+
+The pages can be found in the `/docs/source` directory, with the homepage
+labeled `index.rst`.
+The existing pages can be edited in place to update them, and a new page can be
+created by creating a new `.rst` file alongside the others and adding the
+filename to the `.. toctree::` table of contents in `index.rst`.
+
+To build the website pages, simply `cd` into the `docs` directory and run
+`make html`.
+If you also want to build a LaTeX pdf version of the docs, run `make latexpdf`.
+The built files can be viewed in `/docs/build`.
+To view the website, you can just open `/docs/build/html/index.html` in a
+browser.
+You can keep this *local version* of the website open and simply refresh the
+page to see changes you make after re-building.

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,8 @@ Read the tutorial here:
 
 https://docs.readthedocs.io/en/stable/tutorial/
 
-You will also need `sphinx-copybutton` as well.
+You will also need ``sphinx-copybutton`` as well.
 
-Alternatively, you can get all Python dependences by using
+Alternatively, you can get all Python dependences by using ::
 
-.. code-block:: bash
    pip install -r docs/requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -11,21 +11,21 @@ https://docs.readthedocs.io/en/stable/tutorial/
 Getting Started
 ---------------
 
-To start editing the group wiki, you'll need Python with `Sphinx` installed.
-This can be done through `Pip`, and involves installing the packages `sphinx`
-and `sphinx-rtd-theme`.
+To start editing the group wiki, you'll need Python with **Sphinx** installed.
+This can be done through ``pip``, and involves installing the packages ``sphinx``
+and ``sphinx-rtd-theme``.
 
-The pages can be found in the `/docs/source` directory, with the homepage
-labeled `index.rst`.
+The pages can be found in the ``/docs/source`` directory, with the homepage
+labeled ``index.rst``.
 The existing pages can be edited in place to update them, and a new page can be
-created by creating a new `.rst` file alongside the others and adding the
-filename to the `.. toctree::` table of contents in `index.rst`.
+created by creating a new ``.rst`` file alongside the others and adding the
+filename to the ``.. toctree::`` table of contents in ``index.rst``.
 
-To build the website pages, simply `cd` into the `docs` directory and run
-`make html`.
-If you also want to build a LaTeX pdf version of the docs, run `make latexpdf`.
-The built files can be viewed in `/docs/build`.
-To view the website, you can just open `/docs/build/html/index.html` in a
+To build the website pages, simply ``cd`` into the ``docs`` directory and run
+``make html``.
+If you also want to build a LaTeX pdf version of the docs, run ``make latexpdf``.
+The built files can be viewed in ``/docs/build``.
+To view the website, you can just open ``/docs/build/html/index.html`` in a
 browser.
 You can keep this *local version* of the website open and simply refresh the
 page to see changes you make after re-building.

--- a/README.rst
+++ b/README.rst
@@ -7,3 +7,10 @@ with some basic Sphinx docs.
 Read the tutorial here:
 
 https://docs.readthedocs.io/en/stable/tutorial/
+
+You will also need `sphinx-copybutton` as well.
+
+Alternatively, you can get all Python dependences by using
+
+.. code-block:: bash
+   pip install -r docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# Defining the exact version will make sure things don't break
+sphinx==5.3.0
+sphinx_rtd_theme==1.1.1
+readthedocs-sphinx-search==0.1.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # Defining the exact version will make sure things don't break
-sphinx==5.3.0
-sphinx_rtd_theme==1.1.1
-readthedocs-sphinx-search==0.1.1
+sphinx==7.2.5
+sphinx_rtd_theme==1.3.0
+sphinx-copybutton==0.5.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
-    # 'sphinx_copybutton'
+    'sphinx_copybutton'
 ]
 
 intersphinx_mapping = {


### PR DESCRIPTION
I think I have the copy button working now. The git repository just needs a config file that informs *ReadTheDocs* what version to use to compile and a pip requirements list of which python packages are needed to compile (`sphinx-copybutton` being one needed to compile it).

You can get your local python to grab all the packages in the requirements text file by passing it to `pip install -r /path/to/requirements.txt` to build locally.